### PR TITLE
Feat: 커뮤니티 페이지 및 게시판 리스트 API 구현 및 연동

### DIFF
--- a/src/api/community.ts
+++ b/src/api/community.ts
@@ -1,5 +1,5 @@
 import { communityAPI } from '@lib/axios';
-import { CommunitySchema } from '@schemas/community';
+import { CommunitySchema, NoticeListSchema } from '@schemas/community';
 import { validateResponse } from '@utils/validateResponse';
 
 export const fetchCommunityData = async () => {
@@ -8,4 +8,19 @@ export const fetchCommunityData = async () => {
   // 추후 status code에 따른 에러 처리 필요
 
   return validateResponse(CommunitySchema, response.data);
+};
+
+export const fetchNoticeList = async (page: number, size: number) => {
+  // size는 별도로 전송하지 않고, 10으로 고정해도 될듯함
+  const noticeParams = {
+    params: { page: page, size: size },
+  };
+
+  try {
+    const response = await communityAPI.get('/notices', noticeParams);
+
+    return validateResponse(NoticeListSchema, response.data);
+  } catch (error) {
+    console.error('공지사항 목록 조회 API 요청 실패: ', error);
+  }
 };

--- a/src/api/community.ts
+++ b/src/api/community.ts
@@ -1,5 +1,9 @@
 import { communityAPI } from '@lib/axios';
-import { CommunitySchema, NoticeListSchema } from '@schemas/community';
+import {
+  CommunitySchema,
+  NewsEventListSchema,
+  NoticeListSchema,
+} from '@schemas/community';
 import { validateResponse } from '@utils/validateResponse';
 
 export const fetchCommunityData = async () => {
@@ -22,5 +26,22 @@ export const fetchNoticeList = async (page: number, size: number) => {
     return validateResponse(NoticeListSchema, response.data);
   } catch (error) {
     console.error('공지사항 목록 조회 API 요청 실패: ', error);
+  }
+};
+
+// News & Event 카드 목록 조회 API
+export const fetchNewsEventList = async (page: number, size: number) => {
+  const newsEventParams = {
+    params: { page: page, size: size },
+  };
+
+  try {
+    const response = await communityAPI.get('/newsEvent', newsEventParams);
+
+    // 추후 status code에 따른 에러 처리 필요
+
+    return validateResponse(NewsEventListSchema, response.data);
+  } catch (error) {
+    console.error('News & Event 카드 목록 조회 API 요청 실패: ', error);
   }
 };

--- a/src/api/community.ts
+++ b/src/api/community.ts
@@ -1,0 +1,11 @@
+import { communityAPI } from '@lib/axios';
+import { CommunitySchema } from '@schemas/community';
+import { validateResponse } from '@utils/validateResponse';
+
+export const fetchCommunityData = async () => {
+  const response = await communityAPI.get('/community');
+
+  // 추후 status code에 따른 에러 처리 필요
+
+  return validateResponse(CommunitySchema, response.data);
+};

--- a/src/api/query/communityQuery.ts
+++ b/src/api/query/communityQuery.ts
@@ -1,9 +1,14 @@
-import { fetchCommunityData, fetchNoticeList } from '@api/community';
+import {
+  fetchCommunityData,
+  fetchNewsEventList,
+  fetchNoticeList,
+} from '@api/community';
 import { useQuery } from '@tanstack/react-query';
 
 const COMMUNITY_QUERY_KEYS = {
   community: ['Community'],
   noticeList: (page: number, size: number) => ['NoticeList', page, size],
+  newsEventList: (page: number, size: number) => ['NewsEventList', page, size],
 };
 
 export const useCommunityQuery = () => {
@@ -20,6 +25,16 @@ export const useNoticeListQuery = (page: number, size: number) => {
   return useQuery({
     queryKey: COMMUNITY_QUERY_KEYS.noticeList(page, size),
     queryFn: () => fetchNoticeList(page, size),
+    staleTime: 1000 * 5, // 5초
+    gcTime: 1000 * 30, // 30초
+  });
+};
+
+// News & Event 카드 목록 조회 API Query Hook
+export const useNewsEventListQuery = (page: number, size: number) => {
+  return useQuery({
+    queryKey: COMMUNITY_QUERY_KEYS.newsEventList(page, size),
+    queryFn: () => fetchNewsEventList(page, size),
     staleTime: 1000 * 5, // 5초
     gcTime: 1000 * 30, // 30초
   });

--- a/src/api/query/communityQuery.ts
+++ b/src/api/query/communityQuery.ts
@@ -1,14 +1,25 @@
-import { fetchCommunityData } from '@api/community';
+import { fetchCommunityData, fetchNoticeList } from '@api/community';
 import { useQuery } from '@tanstack/react-query';
 
 const COMMUNITY_QUERY_KEYS = {
   community: ['Community'],
+  noticeList: (page: number, size: number) => ['NoticeList', page, size],
 };
 
 export const useCommunityQuery = () => {
   return useQuery({
     queryKey: COMMUNITY_QUERY_KEYS.community,
     queryFn: fetchCommunityData,
+    staleTime: 1000 * 5, // 5초
+    gcTime: 1000 * 30, // 30초
+  });
+};
+
+// 공지사항 목록 조회 API Query Hook
+export const useNoticeListQuery = (page: number, size: number) => {
+  return useQuery({
+    queryKey: COMMUNITY_QUERY_KEYS.noticeList(page, size),
+    queryFn: () => fetchNoticeList(page, size),
     staleTime: 1000 * 5, // 5초
     gcTime: 1000 * 30, // 30초
   });

--- a/src/api/query/communityQuery.ts
+++ b/src/api/query/communityQuery.ts
@@ -1,0 +1,15 @@
+import { fetchCommunityData } from '@api/community';
+import { useQuery } from '@tanstack/react-query';
+
+const COMMUNITY_QUERY_KEYS = {
+  community: ['Community'],
+};
+
+export const useCommunityQuery = () => {
+  return useQuery({
+    queryKey: COMMUNITY_QUERY_KEYS.community,
+    queryFn: fetchCommunityData,
+    staleTime: 1000 * 5, // 5초
+    gcTime: 1000 * 30, // 30초
+  });
+};

--- a/src/components/Loading/Loading.styled.ts
+++ b/src/components/Loading/Loading.styled.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const LoadingContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  margin-top: 3.2rem;
+`;

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -1,0 +1,7 @@
+import * as S from './Loading.styled';
+
+const Loading = () => {
+  return <S.LoadingContainer>Loading...</S.LoadingContainer>;
+};
+
+export default Loading;

--- a/src/constants/communityCategory.ts
+++ b/src/constants/communityCategory.ts
@@ -1,0 +1,5 @@
+// 공지사항 카테고리
+export const NOTICE_CATEGORY = ['All', 'College TA', 'Council'];
+
+// 뉴스 & 이벤트 카테고리
+export const NEWS_EVENT_CATEGORY = ['All', 'Recruit', 'Award', 'Seminar'];

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -8,7 +8,7 @@ export const exhibitionAPI = axios.create({
   },
 });
 
-export const CommunityFacultyAPI = axios.create({
+export const communityAPI = axios.create({
   baseURL: ENV.API_BASE_URL_JUNBO,
   headers: {
     'Content-Type': 'application/json',

--- a/src/pages/Community/Community.types.ts
+++ b/src/pages/Community/Community.types.ts
@@ -19,9 +19,3 @@ export interface NewsEventCardInfo {
   title: string;
   category: NewsEventType;
 }
-
-export interface NewsEventListInfo {
-  cardInfos: NewsEventCardInfo[];
-  totalPages: number;
-  pageSize: number;
-}

--- a/src/pages/Community/Community.types.ts
+++ b/src/pages/Community/Community.types.ts
@@ -1,46 +1,27 @@
 export type NoticeAuthor = 'TA' | 'Council';
 export type NewsEventType = 'Recruit' | 'Award' | 'Alumni';
 
-export interface NoticeInfos {
-  posts: NoticePostInfo[];
-  totalPages: number;
-  currentPage: number;
-  pageSize: number;
-  totalItems: number;
-}
-
+// 공지사항 API 응답 데이터 타입 정의
 export interface NoticePostInfo {
   id: number;
   title: string;
+  author: NoticeAuthor;
+  createdDate: string;
+  attachmentUrls: string[];
   important: boolean;
-  credit: {
-    postDate: string;
-    author: NoticeAuthor;
-    attatchment: {
-      url: string;
-      name: string;
-    };
-  };
+}
+
+// 뉴스/이벤트 API 응답 데이터 타입 정의
+export interface NewsEventCardInfo {
+  id: number;
+  thumbnailUrl: string;
+  createdDate: string;
+  title: string;
+  category: NewsEventType;
 }
 
 export interface NewsEventListInfo {
   cardInfos: NewsEventCardInfo[];
   totalPages: number;
   pageSize: number;
-}
-
-export interface NewsEventCardInfo {
-  id: number;
-  deadline: string;
-  title: string;
-  category: NewsEventType;
-  imgURL: string;
-}
-
-export interface NewsEventCardProps {
-  route: string;
-  imageURL: string;
-  deadline: string;
-  title: string;
-  category: NewsEventType;
 }

--- a/src/pages/Community/CommunityPage.tsx
+++ b/src/pages/Community/CommunityPage.tsx
@@ -1,15 +1,38 @@
 import { JSX } from 'react/jsx-runtime';
 
+import { useCommunityQuery } from '@api/query/communityQuery';
+import { NewsEventCardInfo, NoticePostInfo } from './Community.types';
+
 import NoticeSection from './Notice/NoticeSection';
 import NewsEventSection from './NewsEvent/NewsEventSection';
 
 import * as S from './CommunityPage.styled';
 
 const CommunityPage = (): JSX.Element => {
+  const {
+    status,
+    data: communityData = { notices: [], newsEvents: [] },
+    error,
+  } = useCommunityQuery();
+
+  console.log('커뮤니티 페이지 Data: ', communityData);
+
+  const noticeBoardData = communityData.notices as NoticePostInfo[];
+
+  const newsEventCardInfos = communityData.newsEvents as NewsEventCardInfo[];
+
   return (
     <S.CommunityPageContainer>
-      <NoticeSection />
-      <NewsEventSection />
+      {status === 'pending' ? (
+        <span>Loading...</span>
+      ) : status === 'error' ? (
+        <span>Error: {error.message}</span>
+      ) : (
+        <>
+          <NoticeSection noticeBoardData={noticeBoardData} />
+          <NewsEventSection newsEventCardInfos={newsEventCardInfos} />
+        </>
+      )}
     </S.CommunityPageContainer>
   );
 };

--- a/src/pages/Community/NewsEvent/Card/NewsEventCard.tsx
+++ b/src/pages/Community/NewsEvent/Card/NewsEventCard.tsx
@@ -1,10 +1,18 @@
 import { JSX } from 'react/jsx-runtime';
 
-import { NewsEventCardProps } from '../../Community.types';
+import { NewsEventType } from '../../Community.types';
 
 import PostTypeBox from '@components/PostTypeBox/PostTypeBox';
 
 import * as S from './NewsEventCard.styled';
+
+interface NewsEventCardProps {
+  route: string;
+  imageURL: string;
+  deadline: string;
+  title: string;
+  category: NewsEventType;
+}
 
 const NewsEventCard = ({
   route,

--- a/src/pages/Community/NewsEvent/Card/NewsEventCard.tsx
+++ b/src/pages/Community/NewsEvent/Card/NewsEventCard.tsx
@@ -8,24 +8,24 @@ import * as S from './NewsEventCard.styled';
 
 interface NewsEventCardProps {
   route: string;
-  imageURL: string;
-  deadline: string;
+  thumbnailUrl: string;
+  createdDate: string;
   title: string;
   category: NewsEventType;
 }
 
 const NewsEventCard = ({
   route,
-  imageURL,
-  deadline,
+  thumbnailUrl,
+  createdDate,
   title,
   category,
 }: NewsEventCardProps): JSX.Element => {
   return (
     <S.NewsEventCardContainer to={route}>
-      <S.CardThumbnail src={imageURL} alt={title} />
+      <S.CardThumbnail src={thumbnailUrl} alt={title} />
       <S.CardInfos>
-        <S.CardDate>{deadline}</S.CardDate>
+        <S.CardDate>{createdDate}</S.CardDate>
         <S.CardTitle>{title}</S.CardTitle>
         <PostTypeBox type={category} />
       </S.CardInfos>

--- a/src/pages/Community/NewsEvent/List/NewsEventList.styled.ts
+++ b/src/pages/Community/NewsEvent/List/NewsEventList.styled.ts
@@ -57,7 +57,7 @@ export const NewsEventCardGridContainer = styled.section`
 
 export const NewsEventCardGrid = styled.ul`
   display: grid;
-  grid-template-rows: repeat(3, 1fr);
+  grid-template-rows: repeat(auto, 1fr);
   grid-template-columns: repeat(4, 1fr);
   gap: 2.4rem 2.3rem;
 `;

--- a/src/pages/Community/NewsEvent/List/NewsEventList.tsx
+++ b/src/pages/Community/NewsEvent/List/NewsEventList.tsx
@@ -1,12 +1,11 @@
-import axios from 'axios';
 import { JSX } from 'react/jsx-runtime';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
+
+import { useNewsEventListQuery } from '@api/query/communityQuery';
 
 import { NEWS_EVENT_CATEGORY } from '@constants/communityCategory';
-import {
-  NewsEventCardInfo,
-  NewsEventListInfo,
-} from '@pages/Community/Community.types';
+
+import { NewsEventCardInfo } from '@pages/Community/Community.types';
 
 import CategoryCommunity from '@components/CategoryCommunity/CategoryCommunity';
 import SearchBar from '@components/SearchBar/SearchBar';
@@ -14,50 +13,22 @@ import Pagination from '@components/Pagination/Pagination';
 import NewsEventCard from '../Card/NewsEventCard';
 
 import * as S from './NewsEventList.styled';
+import Loading from '@components/Loading/Loading';
 
 const NewsEventList = (): JSX.Element => {
   const newsEventTopRef = useRef<HTMLDivElement | null>(null);
 
-  const [newsEventListInfos, setNewsEventListInfos] =
-    useState<NewsEventListInfo | null>(null);
-
-  const [pagePosts, setPagePosts] = useState<NewsEventCardInfo[]>([]);
   const [currentPage, setCurrentPage] = useState<number>(1);
 
   const handleCurrentPage = (page: number) => {
     setCurrentPage(page);
   };
 
-  useEffect(() => {
-    const fetchNewsEventCardData = async () => {
-      try {
-        const response = await axios.get('/data/newsEventList.json');
-        const newsEventListData = response.data;
-        console.log(newsEventListData);
+  // News & Event List API 호출
+  const { status, data, error } = useNewsEventListQuery(currentPage - 1, 10);
 
-        setNewsEventListInfos(newsEventListData);
-
-        if (newsEventListData && newsEventListData.cardInfos) {
-          const indexOfLastPost = currentPage * newsEventListData?.pageSize;
-          const indexOfFirstPost =
-            indexOfLastPost - newsEventListData?.pageSize;
-
-          const newsEventList = newsEventListData?.cardInfos;
-          console.log(newsEventList);
-
-          const currentPageList = newsEventList?.slice(
-            indexOfFirstPost,
-            indexOfLastPost
-          );
-
-          setPagePosts(currentPageList);
-        }
-      } catch (error) {
-        console.error('News & Event card data fetching error', error);
-      }
-    };
-    fetchNewsEventCardData();
-  }, [currentPage]);
+  const newsEventListInfos = data ? (data.content as NewsEventCardInfo[]) : [];
+  const totalPages = data ? data.totalPages : 1;
 
   return (
     <S.NewsEventWrapper ref={newsEventTopRef}>
@@ -77,30 +48,39 @@ const NewsEventList = (): JSX.Element => {
           <SearchBar placeholder="Search" />
         </S.NewsEventTitleSection>
         {/* <S.BoldDivider /> */}
-        <S.NewsEventCardGridContainer>
-          <S.NewsEventCardGrid>
-            {newsEventListInfos?.cardInfos &&
-              pagePosts.map((card) => (
-                <S.NewsEventCardItem key={card.id}>
-                  <NewsEventCard
-                    route={`/community/news-event/${card.id}`}
-                    imageURL={card.imgURL}
-                    deadline={card.deadline}
-                    title={card.title}
-                    category={card.category}
-                  />
-                </S.NewsEventCardItem>
-              ))}
-          </S.NewsEventCardGrid>
-        </S.NewsEventCardGridContainer>
-        <S.PaginationContainer>
-          <Pagination
-            currentPage={currentPage}
-            handleCurrentPage={handleCurrentPage}
-            totalPages={newsEventListInfos?.totalPages}
-            isPreview={true}
-          />
-        </S.PaginationContainer>
+
+        {status === 'pending' ? (
+          <Loading />
+        ) : status === 'error' ? (
+          <span>Error: {error.message}</span>
+        ) : (
+          <>
+            {' '}
+            <S.NewsEventCardGridContainer>
+              <S.NewsEventCardGrid>
+                {newsEventListInfos?.map((card) => (
+                  <S.NewsEventCardItem key={card.id}>
+                    <NewsEventCard
+                      route={`${card.id}`}
+                      thumbnailUrl={card.thumbnailUrl}
+                      createdDate={card.createdDate}
+                      title={card.title}
+                      category={card.category}
+                    />
+                  </S.NewsEventCardItem>
+                ))}
+              </S.NewsEventCardGrid>
+            </S.NewsEventCardGridContainer>
+            <S.PaginationContainer>
+              <Pagination
+                currentPage={currentPage}
+                handleCurrentPage={handleCurrentPage}
+                totalPages={totalPages}
+                isPreview={true}
+              />
+            </S.PaginationContainer>
+          </>
+        )}
       </S.NewsEventContainer>
     </S.NewsEventWrapper>
   );

--- a/src/pages/Community/NewsEvent/List/NewsEventList.tsx
+++ b/src/pages/Community/NewsEvent/List/NewsEventList.tsx
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { JSX } from 'react/jsx-runtime';
 import { useEffect, useRef, useState } from 'react';
 
+import { NEWS_EVENT_CATEGORY } from '@constants/communityCategory';
 import {
   NewsEventCardInfo,
   NewsEventListInfo,
@@ -15,8 +16,6 @@ import NewsEventCard from '../Card/NewsEventCard';
 import * as S from './NewsEventList.styled';
 
 const NewsEventList = (): JSX.Element => {
-  const NewsEventCategory = ['All', 'Recruit', 'Award', 'Alumni'];
-
   const newsEventTopRef = useRef<HTMLDivElement | null>(null);
 
   const [newsEventListInfos, setNewsEventListInfos] =
@@ -64,7 +63,7 @@ const NewsEventList = (): JSX.Element => {
     <S.NewsEventWrapper ref={newsEventTopRef}>
       <S.NewsEventCategoryContainer>
         <CategoryCommunity
-          categoryList={NewsEventCategory}
+          categoryList={NEWS_EVENT_CATEGORY}
           scrollToTopRef={newsEventTopRef}
         />
       </S.NewsEventCategoryContainer>

--- a/src/pages/Community/NewsEvent/NewsEventSection.styled.ts
+++ b/src/pages/Community/NewsEvent/NewsEventSection.styled.ts
@@ -58,7 +58,7 @@ export const NewsEventCardGridContainer = styled.section`
 export const NewsEventCardGrid = styled.ul`
   display: grid;
   grid-template-rows: repeat(2, 1fr);
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 2.4rem 2.3rem;
 `;
 

--- a/src/pages/Community/NewsEvent/NewsEventSection.tsx
+++ b/src/pages/Community/NewsEvent/NewsEventSection.tsx
@@ -3,6 +3,8 @@ import { useRef } from 'react';
 
 import { NewsEventCardInfo } from '../Community.types';
 
+import { NEWS_EVENT_CATEGORY } from '@constants/communityCategory';
+
 import CategoryCommunity from '@components/CategoryCommunity/CategoryCommunity';
 import ViewDetail from '@components/ViewDetail/ViewDetail';
 import NewsEventCard from './Card/NewsEventCard';
@@ -16,15 +18,13 @@ interface NewsEventSectionProps {
 const NewsEventSection = ({
   newsEventCardInfos,
 }: NewsEventSectionProps): JSX.Element => {
-  const NewsEventCategory = ['All', 'Recruit', 'Award', 'Alumni'];
-
   const newsEventTopRef = useRef<HTMLDivElement | null>(null);
 
   return (
     <S.NewsEventWrapper ref={newsEventTopRef}>
       <S.NewsEventCategoryContainer>
         <CategoryCommunity
-          categoryList={NewsEventCategory}
+          categoryList={NEWS_EVENT_CATEGORY}
           scrollToTopRef={newsEventTopRef}
         />
       </S.NewsEventCategoryContainer>

--- a/src/pages/Community/NewsEvent/NewsEventSection.tsx
+++ b/src/pages/Community/NewsEvent/NewsEventSection.tsx
@@ -44,8 +44,8 @@ const NewsEventSection = ({
               <S.NewsEventCardItem key={card.id}>
                 <NewsEventCard
                   route={`news-event/${card.id}`}
-                  imageURL={card.thumbnailUrl}
-                  deadline={card.createdDate}
+                  thumbnailUrl={card.thumbnailUrl}
+                  createdDate={card.createdDate}
                   title={card.title}
                   category={card.category}
                 />

--- a/src/pages/Community/NewsEvent/NewsEventSection.tsx
+++ b/src/pages/Community/NewsEvent/NewsEventSection.tsx
@@ -1,6 +1,5 @@
-import axios from 'axios';
 import { JSX } from 'react/jsx-runtime';
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 
 import { NewsEventCardInfo } from '../Community.types';
 
@@ -10,30 +9,16 @@ import NewsEventCard from './Card/NewsEventCard';
 
 import * as S from './NewsEventSection.styled';
 
-const NewsEventSection = (): JSX.Element => {
+interface NewsEventSectionProps {
+  newsEventCardInfos: NewsEventCardInfo[];
+}
+
+const NewsEventSection = ({
+  newsEventCardInfos,
+}: NewsEventSectionProps): JSX.Element => {
   const NewsEventCategory = ['All', 'Recruit', 'Award', 'Alumni'];
 
   const newsEventTopRef = useRef<HTMLDivElement | null>(null);
-
-  const [newsEventCardInfos, setNewsEventCardInfos] = useState<
-    NewsEventCardInfo[]
-  >([]);
-
-  useEffect(() => {
-    const fetchNewsEventCardData = async () => {
-      try {
-        const response = await axios.get('/data/newsEvent.json');
-        const newsEventCardData = response.data.data;
-        console.log(newsEventCardData);
-
-        setNewsEventCardInfos(newsEventCardData);
-      } catch (error) {
-        console.error('News & Event card data fetching error', error);
-      }
-    };
-
-    fetchNewsEventCardData();
-  }, []);
 
   return (
     <S.NewsEventWrapper ref={newsEventTopRef}>
@@ -58,9 +43,9 @@ const NewsEventSection = (): JSX.Element => {
             {newsEventCardInfos.map((card) => (
               <S.NewsEventCardItem key={card.id}>
                 <NewsEventCard
-                  route={`/community/news-event/${card.id}`}
-                  imageURL={card.imgURL}
-                  deadline={card.deadline}
+                  route={`news-event/${card.id}`}
+                  imageURL={card.thumbnailUrl}
+                  deadline={card.createdDate}
                   title={card.title}
                   category={card.category}
                 />

--- a/src/pages/Community/Notice/Item/NoticeListItem.tsx
+++ b/src/pages/Community/Notice/Item/NoticeListItem.tsx
@@ -1,4 +1,4 @@
-import { NoticeAuthor } from '@pages/Community/Community.types';
+import { NoticePostInfo } from '@pages/Community/Community.types';
 
 import ImportantBox from '@components/ImportantBox/ImportantBox';
 import PostTypeBox from '@components/PostTypeBox/PostTypeBox';
@@ -6,57 +6,45 @@ import { ClipIcon } from '@icons/Clip';
 
 import * as S from './NoticeListItem.styled';
 
-type NoticeListItemProps = {
-  id: number;
-  important: boolean;
-  title: string;
-  date: string;
-  author: NoticeAuthor;
-  attatchment: {
-    url: string;
-    name: string;
-  };
-};
-
 const NoticeListItem = ({
   id,
   important,
   title,
-  date,
+  createdDate,
   author,
-  attatchment,
-}: NoticeListItemProps) => {
-  // 첨부 파일 다운로드 logic
-  const handleDownload = () => {
-    if (id) {
-      // 서버에 저장된 첨부 파일의 URL과 파일명
-      const fileURL = attatchment.url;
-      console.log(fileURL);
+  attachmentUrls,
+}: NoticePostInfo) => {
+  // // 첨부 파일 다운로드 logic
+  // const handleDownload = () => {
+  //   if (id) {
+  //     // 서버에 저장된 첨부 파일의 URL과 파일명
+  //     const fileURL = attatchmentUrl.url;
+  //     console.log(fileURL);
 
-      const fileName = attatchment.name;
-      console.log(fileName);
+  //     const fileName = attatchmentUrl.name;
+  //     console.log(fileName);
 
-      // FE Test를 위한 Blob 객체 사용 구현
-      const blob = new Blob([fileURL], { type: 'application/pdf' }); // Blob 객체 생성
+  //     // FE Test를 위한 Blob 객체 사용 구현
+  //     const blob = new Blob([fileURL], { type: 'application/pdf' }); // Blob 객체 생성
 
-      const link = document.createElement('a');
-      link.href = URL.createObjectURL(blob); // Blob을 가리키는 URL 생성
-      link.download = fileName; // 파일명 설정
-      document.body.appendChild(link);
-      link.click(); // 다운로드 트리거
-      document.body.removeChild(link);
-      URL.revokeObjectURL(link.href); // 메모리 해제
+  //     const link = document.createElement('a');
+  //     link.href = URL.createObjectURL(blob); // Blob을 가리키는 URL 생성
+  //     link.download = fileName; // 파일명 설정
+  //     document.body.appendChild(link);
+  //     link.click(); // 다운로드 트리거
+  //     document.body.removeChild(link);
+  //     URL.revokeObjectURL(link.href); // 메모리 해제
 
-      /* // <a> 태그를 동적으로 생성하여 파일 다운로드를 Trigger (Content-Disposition: attatchment 서버에서 설정 필요)
-      const link = document.createElement("a");
-      link.href = fileURL;
-      link.download = fileName;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      */
-    }
-  };
+  //     /* // <a> 태그를 동적으로 생성하여 파일 다운로드를 Trigger (Content-Disposition: attatchment 서버에서 설정 필요)
+  //     const link = document.createElement("a");
+  //     link.href = fileURL;
+  //     link.download = fileName;
+  //     document.body.appendChild(link);
+  //     link.click();
+  //     document.body.removeChild(link);
+  //     */
+  //   }
+  // };
 
   return (
     <S.NoticeBoardPostRow>
@@ -73,13 +61,13 @@ const NoticeListItem = ({
       </S.PostTitleContainer>
 
       <S.NoticeBoardCredit>
-        <S.UploadDate>{date}</S.UploadDate>
+        <S.UploadDate>{createdDate}</S.UploadDate>
         <S.AuthorBoxArea>
           <PostTypeBox type={author} />
         </S.AuthorBoxArea>
         <S.ClipIconContainer>
-          {attatchment ? (
-            <S.ClipIconButton onClick={handleDownload}>
+          {attachmentUrls.length > 0 ? (
+            <S.ClipIconButton>
               <ClipIcon />
             </S.ClipIconButton>
           ) : (

--- a/src/pages/Community/Notice/List/NoticeList.styled.ts
+++ b/src/pages/Community/Notice/List/NoticeList.styled.ts
@@ -66,7 +66,7 @@ export const NoticeTitle = styled.h2`
 `;
 
 // 게시판 Main
-export const NoticeBoard = styled.section`
+export const NoticeBoard = styled.ul`
   width: 100%;
   height: fit-content;
 

--- a/src/pages/Community/Notice/List/NoticeList.tsx
+++ b/src/pages/Community/Notice/List/NoticeList.tsx
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { JSX } from 'react/jsx-runtime';
 import { useEffect, useRef, useState } from 'react';
 
+import { NOTICE_CATEGORY } from '@constants/communityCategory';
 import { NoticeInfos, NoticePostInfo } from '../../Community.types';
 
 import CategoryCommunity from '@components/CategoryCommunity/CategoryCommunity';
@@ -12,8 +13,6 @@ import Pagination from '@components/Pagination/Pagination';
 import * as S from './NoticeList.styled';
 
 const NoticeList = (): JSX.Element => {
-  const noticeCategory = ['All', 'College TA', 'Council'];
-
   const noticeTopRef = useRef<HTMLDivElement | null>(null);
 
   const [noticeData, setNoticeData] = useState<NoticeInfos | null>(null);
@@ -66,7 +65,7 @@ const NoticeList = (): JSX.Element => {
       <S.NoticeCategoryContainer ref={noticeTopRef}>
         <S.CategoryStickyContainer>
           <CategoryCommunity
-            categoryList={noticeCategory}
+            categoryList={NOTICE_CATEGORY}
             scrollToTopRef={noticeTopRef}
           />
         </S.CategoryStickyContainer>

--- a/src/pages/Community/Notice/List/NoticeList.tsx
+++ b/src/pages/Community/Notice/List/NoticeList.tsx
@@ -1,64 +1,37 @@
-import axios from 'axios';
 import { JSX } from 'react/jsx-runtime';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
+import { useNoticeListQuery } from '@api/query/communityQuery';
 import { NOTICE_CATEGORY } from '@constants/communityCategory';
-import { NoticeInfos, NoticePostInfo } from '../../Community.types';
+
+import { NoticePostInfo } from '@pages/Community/Community.types';
 
 import CategoryCommunity from '@components/CategoryCommunity/CategoryCommunity';
 import NoticeListItem from '../Item/NoticeListItem';
 import SearchBar from '@components/SearchBar/SearchBar';
 import Pagination from '@components/Pagination/Pagination';
+import Loading from '@components/Loading/Loading';
 
 import * as S from './NoticeList.styled';
 
 const NoticeList = (): JSX.Element => {
   const noticeTopRef = useRef<HTMLDivElement | null>(null);
 
-  const [noticeData, setNoticeData] = useState<NoticeInfos | null>(null);
-  const [pagePosts, setPagePosts] = useState<NoticePostInfo[]>([]);
   const [currentPage, setCurrentPage] = useState<number>(1);
 
-  const handleCurrentPage = (page: number) => {
-    setCurrentPage(page);
-  };
+  const handleCurrentPage = (page: number) => setCurrentPage(page);
 
-  // Notice Data Fetching & Sorting (important: true 순으로 정렬)
-  useEffect(() => {
-    const fetchAndSortNoticeData = async () => {
-      try {
-        const response = await axios.get('/data/noticeList.json');
-        const noticeContent = response.data;
-        console.log(noticeContent);
+  const { status, data, error } = useNoticeListQuery(currentPage - 1, 10); // 서버 측에서 page 시작값을 0으로 설정해놔서 임시로 -1 처리
 
-        setNoticeData(noticeContent);
+  const noticeList = data ? (data.content as NoticePostInfo[]) : [];
+  console.log('공지사항 목록 조회 API 응답 데이터: ', noticeList);
 
-        // 데이터가 존재할 때, important: true 순으로 정렬
-        if (noticeContent && noticeContent.posts) {
-          const indexOfLastPost = currentPage * noticeContent?.pageSize;
-          const indexOfFirstPost = indexOfLastPost - noticeContent?.pageSize;
+  // 중요 공지사항 우선순위 정렬
+  const importantAscendingNoticeList = [...noticeList].sort((a, b) => {
+    return Number(b.important) - Number(a.important);
+  });
 
-          const noticePosts = noticeContent?.posts;
-          console.log(noticePosts);
-
-          const sortedbyImportant = [...noticePosts].sort((a, b) => {
-            return b.important - a.important;
-          });
-
-          const currentPosts = sortedbyImportant?.slice(
-            indexOfFirstPost,
-            indexOfLastPost
-          );
-
-          setPagePosts(currentPosts);
-        }
-      } catch (error) {
-        console.error('Notice Data Fetching Error', error);
-      }
-    };
-
-    fetchAndSortNoticeData();
-  }, [currentPage]);
+  const totalPages = data ? data.totalPages : 0;
 
   return (
     <S.NoticeListWrapper>
@@ -81,45 +54,52 @@ const NoticeList = (): JSX.Element => {
           </S.NoticeHeader>
 
           {/* 제목, 공지 일자, 작성자, 첨부파일 */}
-          <S.NoticeBoard>
-            <S.BoardHeaderContainer>
-              <S.NoticeBoardHeaderRow>
-                <S.BoardTitle>제목</S.BoardTitle>
-                <S.NoticeBoardCredit>
-                  <S.UploadDateTitle>공지 일자</S.UploadDateTitle>
-                  <S.AuthorTitle>작성자</S.AuthorTitle>
-                  <S.AttatchmentTitle>첨부 파일</S.AttatchmentTitle>
-                </S.NoticeBoardCredit>
-              </S.NoticeBoardHeaderRow>
-              <S.ThinDivider />
-            </S.BoardHeaderContainer>
+          <S.BoardHeaderContainer>
+            <S.NoticeBoardHeaderRow>
+              <S.BoardTitle>제목</S.BoardTitle>
+              <S.NoticeBoardCredit>
+                <S.UploadDateTitle>공지 일자</S.UploadDateTitle>
+                <S.AuthorTitle>작성자</S.AuthorTitle>
+                <S.AttatchmentTitle>첨부 파일</S.AttatchmentTitle>
+              </S.NoticeBoardCredit>
+            </S.NoticeBoardHeaderRow>
+            <S.ThinDivider />
+          </S.BoardHeaderContainer>
 
-            {/* 게시글 목록 */}
-            {noticeData &&
-              pagePosts?.map((notice) => (
-                <S.BoardHeaderContainer key={notice.id}>
+          {/* 게시글 목록 */}
+          {status === 'pending' ? (
+            <S.NoticeBoard>
+              <Loading />
+            </S.NoticeBoard>
+          ) : status === 'error' ? (
+            <span>Error: {error?.message}</span>
+          ) : (
+            <>
+              {/* 공지사항 목록 */}
+              {importantAscendingNoticeList?.map((notice) => (
+                <S.NoticeBoard key={notice.id}>
                   <NoticeListItem
                     id={notice.id}
                     important={notice.important}
                     title={notice.title}
-                    date={notice.credit.postDate}
-                    author={notice.credit.author}
-                    attatchment={notice.credit.attatchment}
+                    createdDate={notice.createdDate}
+                    author={notice.author}
+                    attachmentUrls={notice.attachmentUrls}
                   />
                   <S.ThinDivider />
-                </S.BoardHeaderContainer>
+                </S.NoticeBoard>
               ))}
-          </S.NoticeBoard>
-
-          {/* Pagination Component */}
-          <S.PaginationWrapper>
-            <Pagination
-              currentPage={currentPage}
-              handleCurrentPage={handleCurrentPage}
-              totalPages={noticeData?.totalPages}
-              isPreview={true}
-            />
-          </S.PaginationWrapper>
+              {/* Pagination */}
+              <S.PaginationWrapper>
+                <Pagination
+                  currentPage={currentPage}
+                  handleCurrentPage={handleCurrentPage}
+                  totalPages={totalPages}
+                  isPreview={true}
+                />
+              </S.PaginationWrapper>
+            </>
+          )}
         </S.NoticeContainer>
       </S.NoticeCategoryContainer>
     </S.NoticeListWrapper>

--- a/src/pages/Community/Notice/NoticeSection.tsx
+++ b/src/pages/Community/Notice/NoticeSection.tsx
@@ -34,7 +34,7 @@ const NoticeSection = ({
             <S.NoticeTitle>
               Notice<span>.</span>
             </S.NoticeTitle>
-            <ViewDetail route={'/community/notice'} />
+            <ViewDetail route={'notice'} />
           </S.NoticeTitleContainer>
           <S.BoldDivider />
         </S.NoticeHeader>

--- a/src/pages/Community/Notice/NoticeSection.tsx
+++ b/src/pages/Community/Notice/NoticeSection.tsx
@@ -1,8 +1,7 @@
-import axios from 'axios';
 import { JSX } from 'react/jsx-runtime';
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 
-import { NoticeInfos, NoticePostInfo } from '../Community.types';
+import { NoticePostInfo } from '../Community.types';
 
 import CategoryCommunity from '@components/CategoryCommunity/CategoryCommunity';
 import NoticeListItem from './Item/NoticeListItem';
@@ -10,50 +9,16 @@ import ViewDetail from '@components/ViewDetail/ViewDetail';
 
 import * as S from './NoticeSection.styled';
 
-const NoticeSection = (): JSX.Element => {
+interface NoticeSectionProps {
+  noticeBoardData: NoticePostInfo[];
+}
+
+const NoticeSection = ({
+  noticeBoardData,
+}: NoticeSectionProps): JSX.Element => {
   const noticeCategory = ['All', 'College TA', 'Council'];
 
   const noticeTopRef = useRef<HTMLDivElement | null>(null);
-
-  const [noticeData, setNoticeData] = useState<NoticeInfos | null>(null);
-  const [pagePosts, setPagePosts] = useState<NoticePostInfo[]>([]);
-
-  // Notice Data Fetching & Sorting (important: true 순으로 정렬)
-  useEffect(() => {
-    const fetchAndSortNoticeData = async () => {
-      try {
-        const response = await axios.get('/data/notice.json');
-        const noticeContent = response.data;
-        console.log(noticeContent);
-
-        setNoticeData(noticeContent);
-
-        // 데이터가 존재할 때, important: true 순으로 정렬
-        if (noticeContent && noticeContent.posts) {
-          const indexOfLastPost = noticeContent?.pageSize;
-          const indexOfFirstPost = indexOfLastPost - noticeContent?.pageSize;
-
-          const noticePosts = noticeContent?.posts;
-          console.log(noticePosts);
-
-          const sortedbyImportant = [...noticePosts].sort((a, b) => {
-            return b.important - a.important;
-          });
-
-          const currentPosts = sortedbyImportant?.slice(
-            indexOfFirstPost,
-            indexOfLastPost
-          );
-
-          setPagePosts(currentPosts);
-        }
-      } catch (error) {
-        console.error('Notice Data Fetching Error', error);
-      }
-    };
-
-    fetchAndSortNoticeData();
-  }, []);
 
   return (
     <S.NoticeCategoryContainer ref={noticeTopRef}>
@@ -89,20 +54,19 @@ const NoticeSection = (): JSX.Element => {
           </S.BoardHeaderContainer>
 
           {/* 게시글 목록 */}
-          {noticeData &&
-            pagePosts?.map((notice) => (
-              <S.BoardHeaderContainer key={notice.id}>
-                <NoticeListItem
-                  id={notice.id}
-                  important={notice.important}
-                  title={notice.title}
-                  date={notice.credit.postDate}
-                  author={notice.credit.author}
-                  attatchment={notice.credit.attatchment}
-                />
-                <S.ThinDivider />
-              </S.BoardHeaderContainer>
-            ))}
+          {noticeBoardData?.map((notice) => (
+            <S.BoardHeaderContainer key={notice.id}>
+              <NoticeListItem
+                id={notice.id}
+                important={notice.important}
+                title={notice.title}
+                createdDate={notice.createdDate}
+                author={notice.author}
+                attachmentUrls={notice.attachmentUrls}
+              />
+              <S.ThinDivider />
+            </S.BoardHeaderContainer>
+          ))}
         </S.NoticeBoard>
       </S.NoticeContainer>
     </S.NoticeCategoryContainer>

--- a/src/schemas/community.ts
+++ b/src/schemas/community.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const CommunitySchema = z.object({
+  notices: z.array(
+    z.object({
+      id: z.number(),
+      title: z.string(),
+      author: z.string(),
+      createdDate: z.string().date(),
+      attachmentUrls: z.array(z.string().url()),
+      important: z.boolean(),
+    })
+  ),
+  newsEvents: z.array(
+    z.object({
+      id: z.number(),
+      thumbnailUrl: z.string().url(),
+      createdDate: z.string().date(),
+      title: z.string(),
+      category: z.string(),
+    })
+  ),
+});

--- a/src/schemas/community.ts
+++ b/src/schemas/community.ts
@@ -21,3 +21,43 @@ export const CommunitySchema = z.object({
     })
   ),
 });
+
+// 공지사항 목록 조회 API 응답 스키마
+export const NoticeListSchema = z.object({
+  content: z.array(
+    z.object({
+      id: z.number(),
+      title: z.string(),
+      author: z.string(),
+      createdDate: z.string().date(),
+      attachmentUrls: z.array(z.string().url()),
+      important: z.boolean(),
+    })
+  ),
+  // 불필요한 페이지네이션 데이터가 너무 많음,,
+  pageable: z.object({
+    pageNumber: z.number(),
+    pageSize: z.number(),
+    sort: z.object({
+      empty: z.boolean(),
+      sorted: z.boolean(),
+      unsorted: z.boolean(),
+    }),
+    offset: z.number(),
+    paged: z.boolean(),
+    unpaged: z.boolean(),
+  }),
+  last: z.boolean(),
+  totalPages: z.number(),
+  totalElements: z.number(),
+  size: z.number(),
+  number: z.number(),
+  sort: z.object({
+    empty: z.boolean(),
+    sorted: z.boolean(),
+    unsorted: z.boolean(),
+  }),
+  numberOfElements: z.number(),
+  first: z.boolean(),
+  empty: z.boolean(),
+});

--- a/src/schemas/community.ts
+++ b/src/schemas/community.ts
@@ -61,3 +61,42 @@ export const NoticeListSchema = z.object({
   first: z.boolean(),
   empty: z.boolean(),
 });
+
+// News & Event 카드 목록 조회 API 응답 스키마 (content 필드만 형식 다름)
+export const NewsEventListSchema = z.object({
+  content: z.array(
+    z.object({
+      id: z.number(),
+      thumbnailUrl: z.string().url(),
+      createdDate: z.string().date(),
+      title: z.string(),
+      category: z.string(),
+    })
+  ),
+  // 불필요한 페이지네이션 데이터가 너무 많음,,
+  pageable: z.object({
+    pageNumber: z.number(),
+    pageSize: z.number(),
+    sort: z.object({
+      empty: z.boolean(),
+      sorted: z.boolean(),
+      unsorted: z.boolean(),
+    }),
+    offset: z.number(),
+    paged: z.boolean(),
+    unpaged: z.boolean(),
+  }),
+  last: z.boolean(),
+  totalPages: z.number(),
+  totalElements: z.number(),
+  size: z.number(),
+  number: z.number(),
+  sort: z.object({
+    empty: z.boolean(),
+    sorted: z.boolean(),
+    unsorted: z.boolean(),
+  }),
+  numberOfElements: z.number(),
+  first: z.boolean(),
+  empty: z.boolean(),
+});


### PR DESCRIPTION
## ✨ PR Content

- API 함수 구현 및 zod를 이용한 타입 검증
- `useCommunityQuery` Hook 구현
- Query 훅 이용한 커뮤니티 페이지 API 연동

> 게시물 페이지는 렌더링 방식을 BE와 상의 필요! (관리자 페이지에서 Rich Text Editor를 사용해 어떻게 값을 저장할지!)

### BE 요청사항 @bjb991123 

- 뉴스/이벤트 Card 카테고리 수정 필요 (아래 사진에 해당하는 카테고리 분류 필요, 공지사항도 마찬가지)

> <img width="121" alt="스크린샷 2025-02-20 오전 3 39 41" src="https://github.com/user-attachments/assets/7c51f29b-67c3-4f70-9671-973424d2e9c7" />


## 📎 Related Issue

Closes #76 

## 📸 Screenshot @bjb991123 
<img width="1720" alt="스크린샷 2025-02-21 오전 1 38 17" src="https://github.com/user-attachments/assets/af92d4d8-5d30-47d8-b917-b0b979a3ee86" />

## 🪄 To Reviewers

none.
